### PR TITLE
Don't inject style if no warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,11 @@ module.exports = postcss.plugin('postcss-messages', function (opts) {
     var styles = ( opts && opts.styles ? opts.styles : defaultStyles );
 
     return function (css, result) {
+        var warnings = result.warnings();
+        if (warnings.length === 0) {
+            return;
+        }
+
         var selector = 'html::before';
         if ( opts && opts.selector ) {
             selector = opts.selector;
@@ -55,7 +60,7 @@ module.exports = postcss.plugin('postcss-messages', function (opts) {
           }
         }
 
-        var content = result.warnings().map(function (message) {
+        var content = warnings.map(function (message) {
             return message.toString().replace(/"/g, '\\"');
         }).join('\\00000a');
 

--- a/test/test.js
+++ b/test/test.js
@@ -57,8 +57,12 @@ describe('postcss-messages', function () {
         test(code, before({ selector: 'html::after', code: code }), [warninger, plugin()]);
     });
 
-    it('not displays warning before body if disabled', function () {
+    it('not displays warning before html if disabled', function () {
         test('a{ }', 'a{ }', [warninger, plugin({ disabled: true })]);
+    });
+
+    it('not displays warning before html if no warnings', function () {
+        test('a{ }', 'a{ }', [plugin()]);
     });
 
     it('displays two warnings from two plugins on new lines', function () {


### PR DESCRIPTION
If there are no warnings and you use the default styling, there used to be a
transparent box with red border/box-shadow at the top of the page.
