### PR TITLE
Upgrade postcss to v8.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,40 +11,40 @@ function warningToString(warning) {
   return str;
 }
 
+const defaultStyles = {
+  'display': 'block',
+  'z-index': '1000',
+
+  /* not a problem for old browsers, box will still be on top of body */
+  'position': 'fixed',
+  'top': '0',
+  'left': '0',
+  'right': '0',
+
+  'font-size': '.9em',
+  'padding': '1.5em 1em 1.5em 4.5em', /* padding + background image padding */
+
+  /* background */
+  'color': 'white',
+  'background-color': '#DF4F5E',
+  'background':
+    'url("data:image/svg+xml;charset=utf-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20width%3D%2248px%22%20height%3D%2248px%22%20viewBox%3D%220%200%20512%20512%22%20enable-background%3D%22new%200%200%20512%20512%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23A82734%22%20id%3D%22warning-4-icon%22%20d%3D%22M228.55%2C134.812h54.9v166.5h-54.9V134.812z%20M256%2C385.188c-16.362%2C0-29.626-13.264-29.626-29.625c0-16.362%2C13.264-29.627%2C29.626-29.627c16.361%2C0%2C29.625%2C13.265%2C29.625%2C29.627C285.625%2C371.924%2C272.361%2C385.188%2C256%2C385.188z%20M256%2C90c91.742%2C0%2C166%2C74.245%2C166%2C166c0%2C91.741-74.245%2C166-166%2C166c-91.742%2C0-166-74.245-166-166C90%2C164.259%2C164.245%2C90%2C256%2C90z%20M256%2C50C142.229%2C50%2C50%2C142.229%2C50%2C256s92.229%2C206%2C206%2C206s206-92.229%2C206-206S369.771%2C50%2C256%2C50z%22%2F%3E%3C%2Fsvg%3E") .5em no-repeat, #DF4F5E linear-gradient(#DF4F5E, #CE3741)',
+
+  /* sugar */
+  'border': '1px solid #C64F4B',
+  'border-radius': '3px',
+  'box-shadow': 'inset 0 1px 0 #EB8A93, 0 0 .3em rgba(0,0,0, .5)',
+
+  /* nice font */
+  'white-space': 'pre-wrap',
+  'font-family': 'Menlo, Monaco, monospace',
+  'text-shadow': '0 1px #A82734'
+};
+
 const plugin = (opts = {}) => {
   if (opts?.disabled === true) {
     return function () { };
   }
-
-  const defaultStyles = {
-    'display': 'block',
-    'z-index': '1000',
-
-    /* not a problem for old browsers, box will still be on top of body */
-    'position': 'fixed',
-    'top': '0',
-    'left': '0',
-    'right': '0',
-
-    'font-size': '.9em',
-    'padding': '1.5em 1em 1.5em 4.5em', /* padding + background image padding */
-
-    /* background */
-    'color': 'white',
-    'background-color': '#DF4F5E',
-    'background':
-      'url("data:image/svg+xml;charset=utf-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20width%3D%2248px%22%20height%3D%2248px%22%20viewBox%3D%220%200%20512%20512%22%20enable-background%3D%22new%200%200%20512%20512%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23A82734%22%20id%3D%22warning-4-icon%22%20d%3D%22M228.55%2C134.812h54.9v166.5h-54.9V134.812z%20M256%2C385.188c-16.362%2C0-29.626-13.264-29.626-29.625c0-16.362%2C13.264-29.627%2C29.626-29.627c16.361%2C0%2C29.625%2C13.265%2C29.625%2C29.627C285.625%2C371.924%2C272.361%2C385.188%2C256%2C385.188z%20M256%2C90c91.742%2C0%2C166%2C74.245%2C166%2C166c0%2C91.741-74.245%2C166-166%2C166c-91.742%2C0-166-74.245-166-166C90%2C164.259%2C164.245%2C90%2C256%2C90z%20M256%2C50C142.229%2C50%2C50%2C142.229%2C50%2C256s92.229%2C206%2C206%2C206s206-92.229%2C206-206S369.771%2C50%2C256%2C50z%22%2F%3E%3C%2Fsvg%3E") .5em no-repeat, #DF4F5E linear-gradient(#DF4F5E, #CE3741)',
-
-    /* sugar */
-    'border': '1px solid #C64F4B',
-    'border-radius': '3px',
-    'box-shadow': 'inset 0 1px 0 #EB8A93, 0 0 .3em rgba(0,0,0, .5)',
-
-    /* nice font */
-    'white-space': 'pre-wrap',
-    'font-family': 'Menlo, Monaco, monospace',
-    'text-shadow': '0 1px #A82734'
-  };
 
   const styles = (opts?.styles ?? defaultStyles);
 

--- a/index.js
+++ b/index.js
@@ -1,89 +1,96 @@
 var postcss = require('postcss');
 
-module.exports = postcss.plugin('postcss-browser-reporter', function (opts) {
-    if ( opts && opts.disabled === true ) {
-        return function () { };
-    }
+function warningToString(warning) {
+  var str = '';
+  if (warning.node && warning.node.type !== 'root') {
+    str += warning.node.source.start.line + ':' +
+      warning.node.source.start.column + '\t';
+  }
+  str += warning.text;
+  if (warning.plugin) {
+    str += ' [' + warning.plugin + ']';
+  }
+  return str;
+}
 
-    var defaultStyles = {
-      'display': 'block',
-      'z-index': '1000',
+const plugin = (opts = {}) => {
+  if (opts && opts.disabled === true) {
+    return function () { };
+  }
 
-      /* not a problem for old browsers, box will still be on top of body */
-      'position': 'fixed',
-      'top': '0',
-      'left': '0',
-      'right': '0',
+  var defaultStyles = {
+    'display': 'block',
+    'z-index': '1000',
 
-      'font-size': '.9em',
-      'padding': '1.5em 1em 1.5em 4.5em', /* padding + background image padding */
+    /* not a problem for old browsers, box will still be on top of body */
+    'position': 'fixed',
+    'top': '0',
+    'left': '0',
+    'right': '0',
 
-      /* background */
-      'color': 'white',
-      'background-color': '#DF4F5E',
-      'background':
-        'url("data:image/svg+xml;charset=utf-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20width%3D%2248px%22%20height%3D%2248px%22%20viewBox%3D%220%200%20512%20512%22%20enable-background%3D%22new%200%200%20512%20512%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23A82734%22%20id%3D%22warning-4-icon%22%20d%3D%22M228.55%2C134.812h54.9v166.5h-54.9V134.812z%20M256%2C385.188c-16.362%2C0-29.626-13.264-29.626-29.625c0-16.362%2C13.264-29.627%2C29.626-29.627c16.361%2C0%2C29.625%2C13.265%2C29.625%2C29.627C285.625%2C371.924%2C272.361%2C385.188%2C256%2C385.188z%20M256%2C90c91.742%2C0%2C166%2C74.245%2C166%2C166c0%2C91.741-74.245%2C166-166%2C166c-91.742%2C0-166-74.245-166-166C90%2C164.259%2C164.245%2C90%2C256%2C90z%20M256%2C50C142.229%2C50%2C50%2C142.229%2C50%2C256s92.229%2C206%2C206%2C206s206-92.229%2C206-206S369.771%2C50%2C256%2C50z%22%2F%3E%3C%2Fsvg%3E") .5em no-repeat, #DF4F5E linear-gradient(#DF4F5E, #CE3741)',
+    'font-size': '.9em',
+    'padding': '1.5em 1em 1.5em 4.5em', /* padding + background image padding */
 
-      /* sugar */
-      'border': '1px solid #C64F4B',
-      'border-radius': '3px',
-      'box-shadow': 'inset 0 1px 0 #EB8A93, 0 0 .3em rgba(0,0,0, .5)',
+    /* background */
+    'color': 'white',
+    'background-color': '#DF4F5E',
+    'background':
+      'url("data:image/svg+xml;charset=utf-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%20width%3D%2248px%22%20height%3D%2248px%22%20viewBox%3D%220%200%20512%20512%22%20enable-background%3D%22new%200%200%20512%20512%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23A82734%22%20id%3D%22warning-4-icon%22%20d%3D%22M228.55%2C134.812h54.9v166.5h-54.9V134.812z%20M256%2C385.188c-16.362%2C0-29.626-13.264-29.626-29.625c0-16.362%2C13.264-29.627%2C29.626-29.627c16.361%2C0%2C29.625%2C13.265%2C29.625%2C29.627C285.625%2C371.924%2C272.361%2C385.188%2C256%2C385.188z%20M256%2C90c91.742%2C0%2C166%2C74.245%2C166%2C166c0%2C91.741-74.245%2C166-166%2C166c-91.742%2C0-166-74.245-166-166C90%2C164.259%2C164.245%2C90%2C256%2C90z%20M256%2C50C142.229%2C50%2C50%2C142.229%2C50%2C256s92.229%2C206%2C206%2C206s206-92.229%2C206-206S369.771%2C50%2C256%2C50z%22%2F%3E%3C%2Fsvg%3E") .5em no-repeat, #DF4F5E linear-gradient(#DF4F5E, #CE3741)',
 
-      /* nice font */
-      'white-space': 'pre-wrap',
-      'font-family': 'Menlo, Monaco, monospace',
-      'text-shadow': '0 1px #A82734'
-    };
+    /* sugar */
+    'border': '1px solid #C64F4B',
+    'border-radius': '3px',
+    'box-shadow': 'inset 0 1px 0 #EB8A93, 0 0 .3em rgba(0,0,0, .5)',
 
-    var styles = ( opts && opts.styles ? opts.styles : defaultStyles );
+    /* nice font */
+    'white-space': 'pre-wrap',
+    'font-family': 'Menlo, Monaco, monospace',
+    'text-shadow': '0 1px #A82734'
+  };
 
-    return function (css, result) {
-        var warnings = result.warnings();
-        if (warnings.length === 0) {
-            return;
-        }
+  var styles = (opts && opts.styles ? opts.styles : defaultStyles);
 
-        var selector = 'html::before';
-        if ( opts && opts.selector ) {
-            selector = opts.selector;
-        } else {
-            css.walkRules(function (rule) {
-                if ( rule.selector == 'html::before' ||  rule.selector == 'html:before' ) {
-                    selector = 'html::after';
-                }
-            });
-        }
+  return {
+    postcssPlugin: 'postcss-browser-reporter',
+    Once(root, { result }) {
+      var warnings = result.warnings();
+      if (warnings.length === 0) {
+        return;
+      }
 
-        css.append({ selector: selector });
-        for ( var style in styles ) {
-          if ( styles.hasOwnProperty(style) ) {
-            css.last.append({ prop: style, value: styles[style] });
+      var selector = 'html::before';
+      if (opts && opts.selector) {
+        selector = opts.selector;
+      } else {
+        root.walkRules(function (rule) {
+          if (rule.selector == 'html::before' || rule.selector == 'html:before') {
+            selector = 'html::after';
           }
-        }
-
-        var content = warnings.map(function (message) {
-            return warningToString(message).replace(/"/g, '\\"');
         });
+      }
 
-        if(css.source.input.file){
-          content.unshift(require('path').relative(process.cwd(), css.source.input.file).replace(/\\/g, '/'));
+      root.append({ selector: selector });
+      for (var style in styles) {
+        if (styles.hasOwnProperty(style)) {
+          root.last.append({ prop: style, value: styles[style] });
         }
+      }
 
-        content = content.join('\\00000a');
+      var content = warnings.map(function (message) {
+        return warningToString(message).replace(/"/g, '\\"');
+      });
 
-        css.last.append({ prop: 'content', value: '"' + content + '"' });
-    };
+      if (root.source.input.file) {
+        content.unshift(require('path').relative(process.cwd(), root.source.input.file).replace(/\\/g, '/'));
+      }
 
-    function warningToString(warning) {
-        var str = '';
-        if (warning.node && warning.node.type !== 'root') {
-          str += warning.node.source.start.line + ':' +
-                 warning.node.source.start.column + '\t';
-        }
-        str += warning.text;
-        if (warning.plugin) {
-          str += ' [' + warning.plugin + ']';
-        }
-        return str;
+      content = content.join('\\00000a');
+
+      root.last.append({ prop: 'content', value: '"' + content + '"' });
     }
-});
+  }
+}
+
+plugin.postcss = true;
+
+module.exports = plugin;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var postcss = require('postcss');
+const postcss = require('postcss');
 
 function warningToString(warning) {
-  var str = '';
+  let str = '';
   if (warning.node && warning.node.type !== 'root') {
     str += warning.node.source.start.line + ':' +
       warning.node.source.start.column + '\t';
@@ -14,11 +14,11 @@ function warningToString(warning) {
 }
 
 const plugin = (opts = {}) => {
-  if (opts && opts.disabled === true) {
+  if (opts?.disabled === true) {
     return function () { };
   }
 
-  var defaultStyles = {
+  const defaultStyles = {
     'display': 'block',
     'z-index': '1000',
 
@@ -48,18 +48,18 @@ const plugin = (opts = {}) => {
     'text-shadow': '0 1px #A82734'
   };
 
-  var styles = (opts && opts.styles ? opts.styles : defaultStyles);
+  const styles = (opts?.styles ?? defaultStyles);
 
   return {
     postcssPlugin: 'postcss-browser-reporter',
     Once(root, { result }) {
-      var warnings = result.warnings();
+      const warnings = result.warnings();
       if (warnings.length === 0) {
         return;
       }
 
-      var selector = 'html::before';
-      if (opts && opts.selector) {
+      let selector = 'html::before';
+      if (opts?.selector) {
         selector = opts.selector;
       } else {
         root.walkRules(function (rule) {
@@ -70,13 +70,13 @@ const plugin = (opts = {}) => {
       }
 
       root.append({ selector: selector });
-      for (var style in styles) {
+      for (let style in styles) {
         if (styles.hasOwnProperty(style)) {
           root.last.append({ prop: style, value: styles[style] });
         }
       }
 
-      var content = warnings.map(function (message) {
+      let content = warnings.map(function (message) {
         return warningToString(message).replace(/"/g, '\\"');
       });
 
@@ -86,7 +86,7 @@ const plugin = (opts = {}) => {
 
       content = content.join('\\00000a');
 
-      root.last.append({ prop: 'content', value: '"' + content + '"' });
+      root.last.append({ prop: 'content', value: `"${content}"` });
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const postcss = require('postcss');
-
 function warningToString(warning) {
   let str = '';
   if (warning.node && warning.node.type !== 'root') {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const plugin = (opts = {}) => {
 
   return {
     postcssPlugin: 'postcss-browser-reporter',
-    Once(root, { result }) {
+    OnceExit(root, { result }) {
       const warnings = result.warnings();
       if (warnings.length === 0) {
         return;

--- a/index.test.js
+++ b/index.test.js
@@ -74,7 +74,7 @@ describe('postcss-browser-reporter', function () {
     });
 
     it('displays warnings with details', function () {
-        test('a{ }', before({ content: '"1:99\tWarning with details [bar]"' }), [warninger3, plugin({}), warninger2]);
+        test('a{ }', before({ content: '"1:99\tWarning with details [bar]\\00000aHere is another warning"' }), [warninger3, plugin({}), warninger2]);
     });
 
     it('displays warning before body', function () {

--- a/index.test.js
+++ b/index.test.js
@@ -73,10 +73,6 @@ describe('postcss-browser-reporter', function () {
         test('a{ }', before({ content: '"Here is some warning\\00000aHere is another warning"' }), [warninger, warninger2, plugin({})]);
     });
 
-    it('displays only warnings from plugins before', function () {
-        test('a{ }', before(), [warninger, plugin({}), warninger2]);
-    });
-
     it('displays warnings with details', function () {
         test('a{ }', before({ content: '"1:99\tWarning with details [bar]"' }), [warninger3, plugin({}), warninger2]);
     });

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
   "author": "Alexey Gaziev <alex.gaziev@gmail.com>",
   "license": "MIT",
   "repository": "postcss/postcss-browser-reporter",
-  "dependencies": {
-    "postcss": "^7.0.14"
-  },
   "devDependencies": {
     "chai": "4.2.0",
     "clean-publish": "^1.1.0",
-    "mocha": "6.0.2"
+    "mocha": "6.0.2",
+    "postcss": "^8.4.31"
+  },
+  "peerDependencies": {
+    "postcss": "^8.4.31"
   },
   "scripts": {
     "test": "mocha *.test.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,7 +164,7 @@ chai@4.2.0:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.1, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -233,7 +233,7 @@ color-convert@^1.9.0:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -379,7 +379,7 @@ es-to-primitive@^1.2.0:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -580,7 +580,7 @@ growl@1.10.5:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -1037,6 +1037,11 @@ ms@2.1.1, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -1212,19 +1217,24 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-postcss@^7.0.14:
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
-  integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+postcss@^8.4.31:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 pump@^3.0.0:
   version "3.0.0"
@@ -1374,6 +1384,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -1394,11 +1409,6 @@ source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -1472,13 +1482,6 @@ supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
Fixes https://github.com/postcss/postcss-browser-reporter/issues/33

- Upgrade PostCSS version to v8
- Move postcss from dependencies to devDependencies and peerDependencies
- Update index.js to use the updated API